### PR TITLE
app: Increase the RFAL worker stack size

### DIFF
--- a/app/prj.conf
+++ b/app/prj.conf
@@ -20,3 +20,6 @@ CONFIG_NCS_ALIRO_RFAL_LOG_LEVEL_DBG=y
 
 # Print reader key that can be provisioned to the User Device
 CONFIG_ALIRO_PRINT_READER_GROUP_ID=y
+
+# RFAL worker stack size (TODO: optimize)
+CONFIG_RFAL_WORKER_THREAD_STACK_SIZE=8192


### PR DESCRIPTION
Set CONFIG_RFAL_WORKER_THREAD_STACK_SIZE to 8k to avoid stack overflow when exchanging Aliro messages.

Fixes: AL-154