### PR TITLE
drivers: Remove polling mechanism from Aliro NFC RFAL driver

### DIFF
--- a/app/src/nfc_transport_impl/nfc_transport_rfal.cpp
+++ b/app/src/nfc_transport_impl/nfc_transport_rfal.cpp
@@ -222,13 +222,6 @@ AliroError NfcTransportRfal::_Init(NfcDriver::Callbacks callbacks)
 		return ALIRO_ERROR_INTERNAL;
 	}
 
-	k_work_init_delayable(&mRecoverWork, [](k_work *workItem) {
-		auto status = Instance().TagDetect(DetectType::REQA);
-		if (status != ALIRO_NO_ERROR) {
-			VerifyAndCall(Instance().NfcDriver::mCallbacks.mOnError, status);
-		}
-	});
-
 	k_timer_init(
 		&mRxTimer,
 		[](k_timer *) {
@@ -298,8 +291,7 @@ AliroError NfcTransportRfal::_StartAnticollision()
 
 AliroError NfcTransportRfal::_RecoverPolling(uint32_t delayMs, DetectType, bool)
 {
-	k_work_reschedule(&mRecoverWork, K_MSEC(delayMs));
-
+	// RFAL automatically recovers to the polling state
 	return ALIRO_NO_ERROR;
 }
 

--- a/app/src/nfc_transport_impl/nfc_transport_rfal.h
+++ b/app/src/nfc_transport_impl/nfc_transport_rfal.h
@@ -67,7 +67,6 @@ private:
 
 	k_timer mRxTimer{};
 	k_timer mIdleTimer{};
-	k_work_delayable mRecoverWork{};
 
 	static constexpr uint32_t sRxTimerTimeoutMs{ CONFIG_RFAL_RX_TIMEOUT_MS };
 	static constexpr uint32_t sIdleTimerTimeoutMs{ CONFIG_RFAL_IDLE_TIMEOUT_MS };


### PR DESCRIPTION
RFAL automatically handles recovering of the reader to the polling mode. Forcing the recovery manually poses wrong timing and the reader may go into sleep mode too fast.

The next step will be removing `RecoverPolling()` and `mOnTimeoutCallback` from Aliro driver interface,
because this is something the driver concrete implementation should handle internally (also NCS based driver).

Fixes AL-153.