### PR TITLE
app: Finish secure session on timeouts propagated from NFC driver

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -95,6 +95,8 @@ static AliroError ErrorHandler(AliroNfcErrorStatusCode statusCode)
 {
 	if (statusCode == AliroNfcErrorStatusCode::kAliroNfcGenericError) {
 		LOG_ERR("Generic error");
+		LOG_INF("Finishing secure session");
+		AccessProtocolCrypto::Instance().FinishSession();
 		return ALIRO_ERROR_INTERNAL;
 	} else {
 		CONTROL_FLOWCommand cmd{};

--- a/app/src/nfc_transport_impl/nfc_transport_rfal.cpp
+++ b/app/src/nfc_transport_impl/nfc_transport_rfal.cpp
@@ -20,6 +20,10 @@ extern "C" struct k_sem irq_sem;
 void NfcTransportRfal::Run()
 {
 	while (true) {
+		if (mTimeout) {
+			VerifyAndCall(Instance().NfcDriver::mCallbacks.mOnError, ALIRO_TIMEOUT);
+			mTimeout = false;
+		}
 		rfalNfcWorker();
 		k_sem_take(&irq_sem, K_MSEC(CONFIG_RFAL_NFC_WORKER_TIMEOUT_MS));
 	}
@@ -60,8 +64,8 @@ void NfcTransportRfal::RfalNotifyCallback(rfalNfcState state)
 		LOG_DBG("RFAL: Data exchange state");
 		break;
 	case RFAL_NFC_STATE_DATAEXCHANGE_DONE:
-		CaptureRxData();
 		k_timer_stop(&mRxTimer);
+		CaptureRxData();
 		k_timer_start(&mIdleTimer, K_MSEC(sIdleTimerTimeoutMs), K_NO_WAIT);
 		break;
 	case RFAL_NFC_STATE_DEACTIVATION:
@@ -226,6 +230,7 @@ AliroError NfcTransportRfal::_Init(NfcDriver::Callbacks callbacks)
 		&mRxTimer,
 		[](k_timer *) {
 			LOG_DBG("RFAL: RX timer expired");
+			Instance().mTimeout = true;
 			Instance().DeselectTag();
 		},
 		nullptr);

--- a/app/src/nfc_transport_impl/nfc_transport_rfal.h
+++ b/app/src/nfc_transport_impl/nfc_transport_rfal.h
@@ -67,6 +67,7 @@ private:
 
 	k_timer mRxTimer{};
 	k_timer mIdleTimer{};
+	bool mTimeout{ false };
 
 	static constexpr uint32_t sRxTimerTimeoutMs{ CONFIG_RFAL_RX_TIMEOUT_MS };
 	static constexpr uint32_t sIdleTimerTimeoutMs{ CONFIG_RFAL_IDLE_TIMEOUT_MS };


### PR DESCRIPTION
- trigger onError callback with ALIRO_TIMEOUT on RX timeout captured in RFAL NFC driver
- terminate the secure session in application code whenever an error appears NFC driver

Fixes an issue with passing RD-NFC-STDTXN-1.0 test case executed multiple times. Note that the TH does not terminate the session with CONTROL_FLOW in this case, so we must use RX timeout for session termination on the reader side.