### PR TITLE
manifest: Bump Aliro stack revision to v0.1.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -22,7 +22,7 @@ manifest:
     - name: aliro
       remote: ncs-ssh
       repo-path: ncs-aliro
-      revision: v0.1.0-rc1
+      revision: v0.1.0
       groups:
         - aliro
       import: false


### PR DESCRIPTION
Updated west manifest with the latest ncs-aliro tag.