### PR TITLE
ci: use runs-on.com for github actions

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,1 @@
+_extends: runs-on-cfg

--- a/.github/workflows/build-aliro-app.yaml
+++ b/.github/workflows/build-aliro-app.yaml
@@ -37,14 +37,16 @@ env:
   ncs_sdk_version: v2.8.0
   aliro_app_folder: app
 
-jobs:  
+jobs:
   build:
-    name: Build    
-    runs-on: ubuntu-22.04
+    name: Build
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - runner=4cpu-linux-x64
 
-    steps: 
+    steps:
       - name: Checkout repository
-        uses: actions/checkout@v4     
+        uses: actions/checkout@v4
 
       - name: Setup sdk
         id: setup-sdk


### PR DESCRIPTION
This is cheaper alternative and provides large variety of runners. See docs: https://runs-on.com/