### PR TITLE
CI: Remove unsupported twister test

### DIFF
--- a/app/sample.yaml
+++ b/app/sample.yaml
@@ -11,6 +11,3 @@ common:
   integration_platforms: *platforms
 tests:
   app.nfc_door_lock: {}
-  app.nfc_door_lock_src_no:
-    extra_args:
-      - CONFIG_NCS_ALIRO_SRC=n


### PR DESCRIPTION
In sample.yaml remove unsupported test app.nfc_door_lock_src_no.