### PR TITLE
1.0.1 fixes and documentation update

### DIFF
--- a/app/sysbuild.cmake
+++ b/app/sysbuild.cmake
@@ -38,8 +38,8 @@ if("uwb_qm35_dfu" IN_LIST SNIPPET)
     set(ext_fw_version "${QM35_IMAGE_VERSION}")
   else()
     find_package(Python3 REQUIRED COMPONENTS Interpreter)
-    set(qm35_impl_scripts_dir applications/doorlock/app/src/aliro/platform/uwb_impl/uwb_qm35_impl/scripts)
-    set(version_mapping_script ${ZEPHYR_NCS_ALIRO_MODULE_DIR}/${qm35_impl_scripts_dir}/map_qm35_version.py)
+    set(version_mapping_script
+        ${CMAKE_CURRENT_LIST_DIR}/src/aliro/platform/uwb_impl/uwb_qm35_impl/scripts/map_qm35_version.py)
     execute_process(COMMAND python3 ${version_mapping_script} ${ext_fw} OUTPUT_VARIABLE ext_fw_version OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif()
 

--- a/docs/firmware_update.rst
+++ b/docs/firmware_update.rst
@@ -216,6 +216,14 @@ To enable QM35 firmware upgrade support, build the application with the ``uwb_qm
 
    west build -b nrf5340dk/nrf5340/cpuapp app -- -DSNIPPET='uwb_qm35_dfu' -Dapp_SNIPPET='uwb_qm35_src;dfu_smp'
 
+When the ``nrfconnect-sdk-qorvo`` west module is present in the workspace, the ``uwb_qm35_dfu`` snippet bundles its default :file:`qm35825.bin` firmware as an additional MCUboot image stored in external flash.
+During the UWB initialization at startup, the application compares versions and updates the QM35 module from this image if an update is required.
+To bundle a QM35 firmware binary from a custom location, pass the path to ``west build`` using the ``QM35_IMAGE_PATH`` CMake variable:
+
+.. code-block:: console
+
+   west build -b nrf54lm20dk/nrf54lm20a/cpuapp app -- -DSNIPPET='uwb_qm35_dfu' -Dapp_SNIPPET='uwb_qm35_src;dfu_smp' -DQM35_IMAGE_PATH='/path/to/qm35825.bin'
+
 Configuration options
 =====================
 
@@ -242,7 +250,7 @@ The QM35 firmware is automatically programmed to external flash together with th
 
    .. code-block:: console
 
-      nrfutil device --x-ext-mem-config-file applications/doorlock/app/boards/nrf54lm20dk_spi_nrfutil_config.json program --firmware build/merged.hex --options verify=VERIFY_READ,ext_mem_erase_mode=ERASE_RANGES_TOUCHED_BY_FIRMWARE,reset=RESET_SOFT
+      nrfutil device --x-ext-mem-config-file app/boards/nrf54lm20dk_spi_nrfutil_config.json program --firmware build/merged.hex --options verify=VERIFY_READ,ext_mem_erase_mode=ERASE_RANGES_TOUCHED_BY_FIRMWARE,reset=RESET_SOFT
 
 Firmware upgrade procedure
 ==========================

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -66,11 +66,34 @@ The following table shows tested and verified combinations of |REPO_NAME| releas
      - 1.5.0
      - 0.6.0
      - 4.0.2
+   * - 1.0.1
+     - 3.2.0
+     - 1.0.0
+     - 1.5.0
+     - 0.6.0
+     - 4.0.2
 
 Release notes
 *************
 
 The following list outlines the release notes for each release of the |REPO_NAME|.
+
+v1.0.1
+******
+
+This is a bugfix release that fixes the Device Firmware Update process for the QM35.
+Specifically, it fixes the QM35 firmware version mapping script path used during sysbuild when building with the ``uwb_qm35_dfu`` snippet.
+
+Changelog
+=========
+
+.. toggle::
+
+  The following updates were introduced in this release.
+
+  * Fixed:
+
+    * Incorrect path to the QM35 version mapping script (``map_qm35_version.py``) in sysbuild.
 
 v1.0.0
 ******


### PR DESCRIPTION
doc: Added release notes for 1.0.1    

 - Updated release notes and compatibility matrix
    
Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>

doc: Extend the QM35 firmware update section
    
- Added description of the QM35 FW update process
- Fixed invalid path in the flash command for nRF54LM20

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>

 sysbuild: Fix the path to the QM35 version mapping scipt

 - Added proper location of the script in the source tree

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>


