### PR TITLE
doc: Fix publishing and the link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Aliro standardizes the interaction that lets a phone or wearable act as a digita
 
 ## Getting started
 
-To get started with the nRF Door Lock and Access Control Add-on, follow the [documentation](https://docs.nordicsemi.com/bundle/aliro_1.0.0/page/index.html).
+To get started with the nRF Door Lock and Access Control Add-on, follow the [documentation](https://nrfconnectdocs.nordicsemi.com/addons/door_lock_and_access_control/latest/index.html).
 
 ## License
 

--- a/docs/_zoomin/aliro.custom.properties
+++ b/docs/_zoomin/aliro.custom.properties
@@ -1,0 +1,2 @@
+manual.name=door_lock_and_access_control___VERSION__
+booktitle=nRF Door Lock and Access Control Add-on - __VERSION__

--- a/docs/_zoomin/aliro.tags.yml
+++ b/docs/_zoomin/aliro.tags.yml
@@ -1,0 +1,10 @@
+# Document tags for Zoomin.
+
+# Tags for all topics:
+mapping_global:
+  - aliro
+  - door_lock_and_access_control___VERSION__
+  - cluster_door_lock_and_access_control___VERSION__
+
+# Tags for individual topics:
+mapping_topics: []


### PR DESCRIPTION
doc: Fix the documentation link
    
- Use the new hosting service name and the latest tag

ci: Bring back the Zoomin configuration files
    
 - Added custom.properties and tags needed to publish the latest documentation

