### PR TITLE
matter_access: Fix UserIndex value reported in LockOperation event

### DIFF
--- a/applications/matter-aliro-door-lock-app/src/matter/app_task.cpp
+++ b/applications/matter-aliro-door-lock-app/src/matter/app_task.cpp
@@ -225,14 +225,14 @@ void AppTask::UpdateClusterStateHandler(const BoltLockManager::StateData &stateD
 	} else {
 		LOG_INF("Updating LockState attribute");
 
-		Nullable<uint16_t> userId;
+		Nullable<uint16_t> userIndex;
 		Nullable<List<const LockOpCredentials>> credentials;
 #ifdef CONFIG_LOCK_PASS_CREDENTIALS_TO_SET_LOCK_STATE
 		List<const LockOpCredentials> credentialList;
 #endif
 
 		if (!stateData.mValidateCredentialResult.IsNull()) {
-			userId = { stateData.mValidateCredentialResult.Value().mUserId };
+			userIndex = { stateData.mValidateCredentialResult.Value().mUserIndex };
 
 #ifdef CONFIG_LOCK_PASS_CREDENTIALS_TO_SET_LOCK_STATE
 			/* `DoorLockServer::SetLockState` exptects list of `LockOpCredentials`,
@@ -244,8 +244,9 @@ void AppTask::UpdateClusterStateHandler(const BoltLockManager::StateData &stateD
 #endif
 		}
 
-		if (!DoorLockServer::Instance().SetLockState(kLockEndpointId, newLockState, stateData.mSource, userId,
-							     credentials, stateData.mFabricIdx, stateData.mNodeId)) {
+		if (!DoorLockServer::Instance().SetLockState(kLockEndpointId, newLockState, stateData.mSource,
+							     userIndex, credentials, stateData.mFabricIdx,
+							     stateData.mNodeId)) {
 			LOG_ERR("Failed to update LockState attribute");
 		}
 	}

--- a/applications/matter-door-lock-app/src/app_task.cpp
+++ b/applications/matter-door-lock-app/src/app_task.cpp
@@ -181,14 +181,14 @@ void AppTask::UpdateClusterStateHandler(const BoltLockManager::StateData &stateD
 	} else {
 		LOG_INF("Updating LockState attribute");
 
-		Nullable<uint16_t> userId;
+		Nullable<uint16_t> userIndex;
 		Nullable<List<const LockOpCredentials>> credentials;
 #ifdef CONFIG_LOCK_PASS_CREDENTIALS_TO_SET_LOCK_STATE
 		List<const LockOpCredentials> credentialList;
 #endif
 
 		if (!stateData.mValidateCredentialResult.IsNull()) {
-			userId = { stateData.mValidateCredentialResult.Value().mUserId };
+			userIndex = { stateData.mValidateCredentialResult.Value().mUserIndex };
 
 #ifdef CONFIG_LOCK_PASS_CREDENTIALS_TO_SET_LOCK_STATE
 			/* `DoorLockServer::SetLockState` exptects list of `LockOpCredentials`,
@@ -200,8 +200,9 @@ void AppTask::UpdateClusterStateHandler(const BoltLockManager::StateData &stateD
 #endif
 		}
 
-		if (!DoorLockServer::Instance().SetLockState(kLockEndpointId, newLockState, stateData.mSource, userId,
-							     credentials, stateData.mFabricIdx, stateData.mNodeId)) {
+		if (!DoorLockServer::Instance().SetLockState(kLockEndpointId, newLockState, stateData.mSource,
+							     userIndex, credentials, stateData.mFabricIdx,
+							     stateData.mNodeId)) {
 			LOG_ERR("Failed to update LockState attribute");
 		}
 	}

--- a/subsys/matter_access/include/matter_access/access_manager.h
+++ b/subsys/matter_access/include/matter_access/access_manager.h
@@ -18,7 +18,7 @@ template <Data::CredentialsBits CRED_BIT_MASK> class AccessManager {
 
 public:
 	struct ValidateCredentialResult {
-		uint16_t mUserId;
+		uint16_t mUserIndex;
 		LockOpCredentials mCredential;
 	};
 
@@ -370,8 +370,8 @@ private:
 	void LoadSchedulesFromPersistentStorage();
 #endif // CONFIG_DOOR_LOCK_MATTER_ACCESS_SCHEDULES
 
-	static CHIP_ERROR GetCredentialUser(uint16_t credentialIndex, CredentialTypeEnum credentialType,
-					    Data::User **userPtr);
+	static CHIP_ERROR GetCredentialUserIndex(uint16_t credentialIndex, CredentialTypeEnum credentialType,
+						 uint16_t &userIndex);
 
 	/* Similarly to SetCredential(), credentialIndex starts from 1 */
 	static bool DoSetCredential(Data::Credential &credential, uint16_t credentialIndex, chip::FabricIndex creator,

--- a/subsys/matter_access/src/access_manager.cpp
+++ b/subsys/matter_access/src/access_manager.cpp
@@ -131,10 +131,10 @@ bool AccessManager<CRED_BIT_MASK>::ValidateCredential(CredentialTypeEnum credent
 			continue;
 		}
 
-		Data::User *user{ nullptr };
-		if (GetCredentialUser(static_cast<uint16_t>(index), credentialType, &user) == CHIP_NO_ERROR) {
+		uint16_t userIndex{};
+		if (GetCredentialUserIndex(static_cast<uint16_t>(index), credentialType, userIndex) == CHIP_NO_ERROR) {
 			result = ValidateCredentialResult{
-				.mUserId = static_cast<uint16_t>(user->mInfo.mFields.mUserUniqueId),
+				.mUserIndex = userIndex,
 				.mCredential = LockOpCredentials{ credentialType, static_cast<uint16_t>(index) },
 			};
 		} else {

--- a/subsys/matter_access/src/access_manager_credentials.cpp
+++ b/subsys/matter_access/src/access_manager_credentials.cpp
@@ -67,10 +67,11 @@ CHIP_ERROR AccessManager<CRED_BIT_MASK>::UpdateAliroEvictableCredential(uint16_t
 			    CHIP_ERROR_INVALID_ARGUMENT);
 
 	/* Find the User with Credential Issuer credential */
-	Data::User *credentialIssuerUser{ nullptr };
-	VerifyOrReturnError(CHIP_NO_ERROR == Instance().GetCredentialUser(credentialIssuerIndex,
-									  CredentialTypeEnum::kAliroCredentialIssuerKey,
-									  &credentialIssuerUser),
+	uint16_t credentialIssuerUserIndex{};
+	VerifyOrReturnError(CHIP_NO_ERROR ==
+				    Instance().GetCredentialUserIndex(credentialIssuerIndex,
+								      CredentialTypeEnum::kAliroCredentialIssuerKey,
+								      credentialIssuerUserIndex),
 			    CHIP_ERROR_NOT_FOUND);
 
 	/* Find the credential array in the credentials database */
@@ -80,7 +81,8 @@ CHIP_ERROR AccessManager<CRED_BIT_MASK>::UpdateAliroEvictableCredential(uint16_t
 	VerifyOrReturnError(success, CHIP_ERROR_INTERNAL);
 
 	/* Add Evictable Credential to the User's credentials list */
-	VerifyOrReturnError(CHIP_NO_ERROR == credentialIssuerUser->AddAliroEvictableCredential(credentialIndex),
+	auto &credentialIssuerUser = Instance().mUsers[credentialIssuerUserIndex - 1];
+	VerifyOrReturnError(CHIP_NO_ERROR == credentialIssuerUser.AddAliroEvictableCredential(credentialIndex),
 			    CHIP_ERROR_INTERNAL);
 
 	/* Update the Evictable Credential in the credentials database */
@@ -139,7 +141,7 @@ bool AccessManager<CRED_BIT_MASK>::DoSetCredential(Data::Credential &credential,
 						   DlCredentialStatus credentialStatus,
 						   CredentialTypeEnum credentialType, const ByteSpan &secret)
 {
-	Data::User *user{ nullptr };
+	uint16_t userIndex{};
 	credential.mInfo.mFields.mStatus = static_cast<uint8_t>(credentialStatus);
 	credential.mInfo.mFields.mCredentialType = static_cast<uint8_t>(credentialType);
 	credential.mInfo.mFields.mCreationSource = static_cast<uint8_t>(DlAssetSource::kMatterIM);
@@ -150,7 +152,7 @@ bool AccessManager<CRED_BIT_MASK>::DoSetCredential(Data::Credential &credential,
 	if (!secret.empty()) {
 		credential.mSecret.mDataLength = secret.size();
 		memcpy(credential.mSecret.mData, secret.data(), secret.size());
-	} else if (CHIP_NO_ERROR == Instance().GetCredentialUser(credentialIndex, credentialType, &user)) {
+	} else if (CHIP_NO_ERROR == Instance().GetCredentialUserIndex(credentialIndex, credentialType, userIndex)) {
 		/* Credential already exists, and the new secret is empty, so the credential is being cleared.
 		 * Inform the higher layer about clearing the credential and provide current credential data.
 		 */
@@ -203,7 +205,7 @@ bool AccessManager<CRED_BIT_MASK>::DoSetCredential(Data::Credential &credential,
 		credential.mInfo.mFields.mStatus == static_cast<uint8_t>(DlCredentialStatus::kAvailable) ? "available" :
 													   "occupied");
 
-	if (CHIP_NO_ERROR == Instance().GetCredentialUser(credentialIndex, credentialType, &user)) {
+	if (CHIP_NO_ERROR == Instance().GetCredentialUserIndex(credentialIndex, credentialType, userIndex)) {
 		if (Instance().mSetCredentialCallback && credential.mSecret.mDataLength > 0) {
 			ByteSpan secret = { credential.mSecret.mData, credential.mSecret.mDataLength };
 			Instance().mSetCredentialCallback(credentialIndex, credentialType, secret);
@@ -214,12 +216,10 @@ bool AccessManager<CRED_BIT_MASK>::DoSetCredential(Data::Credential &credential,
 }
 
 template <Data::CredentialsBits CRED_BIT_MASK>
-CHIP_ERROR AccessManager<CRED_BIT_MASK>::GetCredentialUser(uint16_t credentialIndex, CredentialTypeEnum credentialType,
-							   Data::User **userPtr)
+CHIP_ERROR AccessManager<CRED_BIT_MASK>::GetCredentialUserIndex(uint16_t credentialIndex,
+								CredentialTypeEnum credentialType, uint16_t &userIndex)
 {
-	VerifyOrReturnError(userPtr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-
-	*userPtr = nullptr;
+	userIndex = 0;
 
 	for (size_t idxUsr = 0; idxUsr < CONFIG_DOOR_LOCK_MATTER_ACCESS_MAX_NUM_USERS; ++idxUsr) {
 		auto &user = Instance().mUsers[idxUsr];
@@ -229,7 +229,7 @@ CHIP_ERROR AccessManager<CRED_BIT_MASK>::GetCredentialUser(uint16_t credentialIn
 			auto &credentialStruct = user.mOccupiedCredentials.mData[idxCred];
 			if (credentialStruct.credentialIndex == credentialIndex &&
 			    credentialStruct.credentialType == credentialType) {
-				*userPtr = &user;
+				userIndex = static_cast<uint16_t>(idxUsr + 1);
 				return CHIP_NO_ERROR;
 			}
 		}


### PR DESCRIPTION
* Update AccessManager API to return UserIndex instead pointer to User structure.
* Use UserIndex instead of UserUniqueId for ValidateCredentialResult.
* Rename members and variables from userId to userIndex.