### PR TITLE
ci: Fix SonarQube workflow cache

### DIFF
--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -89,7 +89,9 @@ jobs:
         run: |
           west init -l
           west config manifest.group-filter -- "+qm35-aliro-sdk"
-          west patch clean
+          if [ "${{ steps.cache-west.outputs.cache-hit }}" == "true" ]; then
+            west patch clean
+          fi
           west update -o=--depth=1 -n
           west patch apply
 


### PR DESCRIPTION
Don't run `west patch clean` when there is no cache, as it will fail due to unknown command.