### PR TITLE
module: Add Qorvo vendor1 extensions

### DIFF
--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -89,9 +89,7 @@ jobs:
         run: |
           west init -l
           west config manifest.group-filter -- "+qm35-aliro-sdk"
-          if [ "${{ steps.cache-west.outputs.cache-hit }}" == "true" ]; then
-            west patch clean
-          fi
+          west patch clean || true
           west update -o=--depth=1 -n
           west patch apply
 

--- a/west.yml
+++ b/west.yml
@@ -24,6 +24,13 @@ manifest:
       revision: v1.1.0
       groups:
         - ncs-door-lock-app-extensions
+    - name: vendor1
+      url: https://gitlab.com/qorvo/qswg/public/vendor1
+      revision: release/QM35ALIRO_ENG-0.7.0
+      path: qm35-aliro-sdk/project/cherry/vendor1
+      groups:
+        - vendor1
   group-filter:
     - -qm35-aliro-sdk
     - -ncs-door-lock-app-extensions
+    - -vendor1

--- a/zephyr/patches.yml
+++ b/zephyr/patches.yml
@@ -35,3 +35,9 @@ patches:
     author: Marcin Kajor
     email: marcin.kajor@nordicsemi.no
     date: 2026-04-29
+  - path: vendor1/vendor1.patch
+    sha256sum: bc557d0b0addfaf50d66f9c47699478c7e7074f9fbb03063b1a4bf9a4044d5de
+    module: qm35-aliro-sdk/project/cherry/vendor1
+    author: Marcin Kajor
+    email: marcin.kajor@nordicsemi.no
+    date: 2026-04-28

--- a/zephyr/patches/vendor1/vendor1.patch
+++ b/zephyr/patches/vendor1/vendor1.patch
@@ -1,0 +1,21 @@
+From 0f50c9507c4198982267f9495acb9ea3b69db0dd Mon Sep 17 00:00:00 2001
+From: Marcin Kajor <marcin.kajor@nordicsemi.no>
+Date: Tue, 28 Apr 2026 11:37:09 +0200
+Subject: [PATCH 1/1] cmake: Fix the vendor1 public API access
+
+- Added missing include path in the CMake configuration
+
+Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>
+---
+ aliro_uwb_adapter/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/aliro_uwb_adapter/CMakeLists.txt b/aliro_uwb_adapter/CMakeLists.txt
+index ea71fb5..fb2d85f 100644
+--- a/aliro_uwb_adapter/CMakeLists.txt
++++ b/aliro_uwb_adapter/CMakeLists.txt
+@@ -11,0 +12 @@ list(APPEND ALIRO_ADAPTER_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_LIST_DIR}/include)
++list(APPEND ALIRO_ADAPTER_INCLUDE_DIRECTORIES ${CHERRY_TOP}/vendor1/cherry/include)
+-- 
+2.52.0
+


### PR DESCRIPTION
Add Qorvo vendor1 extensions for QM35 UWB to west manifest.
Add patch with include path fix.