### PR TITLE
doc: Fix application name

### DIFF
--- a/docs/aliro_matter_application/testing/verification_and_testing.rst
+++ b/docs/aliro_matter_application/testing/verification_and_testing.rst
@@ -27,6 +27,6 @@ Once you have successfully provisioned Aliro credentials, perform tests to ensur
 
 .. code-block:: bash
 
-   west build -b nrf5340dk/nrf5340/cpuapp applications/aliro-access-control-app -- -Daliro-access-control-app_SNIPPET=uwb_qm35 -DCONFIG_DOOR_LOCK_EXPEDITED_FAST_PHASE=y -DCONFIG_DOOR_LOCK_STEP_UP_PHASE=y -DCONFIG_DOOR_LOCK_CREDENTIAL_ISSUER_CA=y
+   west build -b nrf5340dk/nrf5340/cpuapp applications/matter-aliro-door-lock-app -- -Dmatter-aliro-door-lock-app_SNIPPET=uwb_qm35 -DCONFIG_DOOR_LOCK_EXPEDITED_FAST_PHASE=y -DCONFIG_DOOR_LOCK_STEP_UP_PHASE=y -DCONFIG_DOOR_LOCK_CREDENTIAL_ISSUER_CA=y
 
 .. include:: /include/testing_verification_tail.txt


### PR DESCRIPTION
Replace `aliro-access-control-app` with `matter-aliro-door-lock-app` in `matter-aliro-door-lock-app` docs.