### PR TITLE
samples: Adjust dfu tags in sample.yaml

### DIFF
--- a/applications/aliro-access-control-app/sample.yaml
+++ b/applications/aliro-access-control-app/sample.yaml
@@ -5,9 +5,9 @@ common:
   sysbuild: true
   build_only: true
 tests:
-  smoke.door_lock.nfc-uwb.qm35_dfu-dfu_smp:
+  smoke.door_lock.nfc-uwb.qm35_dfu-smp_dfu:
     tags:
-      - dfu_smp
+      - dfu_supported
     platform_allow: &platform_5340
       - nrf5340dk/nrf5340/cpuapp
     integration_platforms: *platform_5340
@@ -15,9 +15,9 @@ tests:
       - SNIPPET="uwb_qm35_dfu"
       - aliro-access-control-app_SNIPPET="uwb_qm35;dfu_smp"
       - CONFIG_DOOR_LOCK_ALIRO_UWB_QM35_DFU_VERSION_COMPARISON_DIFFERENT=y
-  app.door_lock.nfc-uwb.qm35_dfu-dfu_smp:
+  app.door_lock.nfc-uwb.qm35_dfu-smp_dfu:
     tags:
-      - dfu_smp
+      - dfu_supported
     platform_allow: &platform_54lm20
       - nrf54lm20dk/nrf54lm20b/cpuapp
     integration_platforms: *platform_54lm20
@@ -37,9 +37,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
     integration_platforms: *platform_52840_5340
-  app.door_lock.nfc-uwb.dfu_smp-bt_nus:
+  app.door_lock.nfc-uwb.smp_dfu-bt_nus:
     tags:
-      - dfu_smp
+      - dfu_supported
     platform_allow: &platform_5340_54lm20
       - nrf5340dk/nrf5340/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
@@ -55,9 +55,9 @@ tests:
       - CONFIG_DOOR_LOCK_STEP_UP_PHASE=n
       - CONFIG_DOOR_LOCK_CREDENTIAL_ISSUER_CA=n
       - CONFIG_DOOR_LOCK_READER_CERTIFICATE=n
-  app.door_lock.nfc-uwb.dfu_smp-release:
+  app.door_lock.nfc-uwb.smp_dfu-release:
     tags:
-      - dfu_smp
+      - dfu_supported
     platform_allow: *platform_5340_54lm20
     integration_platforms: *platform_5340_54lm20
     extra_args:

--- a/applications/matter-aliro-door-lock-app/sample.yaml
+++ b/applications/matter-aliro-door-lock-app/sample.yaml
@@ -7,7 +7,7 @@ common:
 tests:
   app.door_lock.nfc-uwb.matter:
     tags:
-      - matter
+      - dfu_supported
     platform_allow: &platform_5340
       - nrf5340dk/nrf5340/cpuapp
     integration_platforms: *platform_5340
@@ -15,7 +15,7 @@ tests:
       - matter-aliro-door-lock-app_SNIPPET="uwb_qm35"
   smoke.door_lock.nfc-uwb.matter-qm35_dfu-reader_cert-ci_ca_key:
     tags:
-      - matter
+      - dfu_supported
     platform_allow: &platform_54lm20
       - nrf54lm20dk/nrf54lm20b/cpuapp
     integration_platforms: *platform_54lm20
@@ -27,7 +27,7 @@ tests:
       - CONFIG_DOOR_LOCK_READER_CERTIFICATE=y
   app.door_lock.nfc.matter-ci_ca_key-reader_cert:
     tags:
-      - matter
+      - dfu_supported
     platform_allow: &platform_54l15_54lm20
       - nrf54l15dk/nrf54l15/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
@@ -37,7 +37,7 @@ tests:
       - CONFIG_DOOR_LOCK_READER_CERTIFICATE=y
   smoke.door_lock.nfc.matter-ci_ca_key-reader_cert:
     tags:
-      - matter
+      - dfu_supported
     platform_allow: &platform_52840_5340
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
@@ -47,22 +47,21 @@ tests:
       - CONFIG_DOOR_LOCK_READER_CERTIFICATE=y
   app.door_lock.nfc-uwb.matter-bt_nus:
     tags:
-      - matter
+      - dfu_supported
     platform_allow: *platform_5340
     integration_platforms: *platform_5340
     extra_args:
       - matter-aliro-door-lock-app_SNIPPET="uwb_qm35;bt_nus"
-  app.door_lock.nfc-uwb.matter-dfu_smp-bt_nus:
+  app.door_lock.nfc-uwb.matter-smp_dfu-bt_nus:
     tags:
-      - dfu_smp
-      - matter
+      - dfu_supported
     platform_allow: *platform_54lm20
     integration_platforms: *platform_54lm20
     extra_args:
       - matter-aliro-door-lock-app_SNIPPET="uwb_qm35;dfu_smp;bt_nus"
   app.door_lock.nfc.matter-aliro_minimal:
     tags:
-      - matter
+      - dfu_supported
     platform_allow: &platform_54l15
       - nrf54l15dk/nrf54l15/cpuapp
     integration_platforms: *platform_54l15
@@ -71,10 +70,9 @@ tests:
       - CONFIG_DOOR_LOCK_STEP_UP_PHASE=n
       - CONFIG_DOOR_LOCK_CREDENTIAL_ISSUER_CA=n
       - CONFIG_DOOR_LOCK_READER_CERTIFICATE=n
-  app.door_lock.nfc-uwb.matter-dfu_smp-release:
+  app.door_lock.nfc-uwb.matter-smp_dfu-release:
     tags:
-      - matter
-      - dfu_smp
+      - dfu_supported
     platform_allow: &platform_5340_54lm20
       - nrf5340dk/nrf5340/cpuapp
       - nrf54lm20dk/nrf54lm20b/cpuapp
@@ -84,7 +82,7 @@ tests:
       - FILE_SUFFIX=release
   app.door_lock.nfc.matter-bt_nus-release:
     tags:
-      - matter
+      - dfu_supported
     platform_allow: &platform_all
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp

--- a/applications/matter-door-lock-app/sample.yaml
+++ b/applications/matter-door-lock-app/sample.yaml
@@ -10,7 +10,7 @@ tests:
     sysbuild: true
     build_only: true
     tags:
-      - smoke
+      - dfu_supported
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
     platform_allow:
@@ -21,6 +21,8 @@ tests:
   sample.matter.lock.release:
     sysbuild: true
     build_only: true
+    tags:
+      - dfu_supported
     extra_args:
       - FILE_SUFFIX=release
     integration_platforms:
@@ -34,6 +36,8 @@ tests:
   sample.matter.lock.smp_dfu:
     sysbuild: true
     build_only: true
+    tags:
+      - dfu_supported
     extra_args:
       - matter-door-lock-app_SNIPPET="dfu_smp"
     integration_platforms:
@@ -48,6 +52,8 @@ tests:
   sample.matter.lock.nus:
     sysbuild: true
     build_only: true
+    tags:
+      - dfu_supported
     extra_args:
       - matter-door-lock-app_SNIPPET=bt_nus
       - CONFIG_DOOR_LOCK_BLE_MANAGER_AUTH_APP_PASSKEY=112233
@@ -61,6 +67,8 @@ tests:
   sample.matter.lock.schedules:
     sysbuild: true
     build_only: true
+    tags:
+      - dfu_supported
     extra_args:
       - EXTRA_CONF_FILE=schedules.conf
     integration_platforms:


### PR DESCRIPTION
This PR adds dfu tags in matter-door-lock-app sample.yaml It also unifies dfu_smp and matter tags into one tag dfu_supported