### PR TITLE
app: reduce SPI frequency to 4 MHz

### DIFF
--- a/applications/aliro-access-control-app/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/applications/aliro-access-control-app/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -46,7 +46,7 @@
 	nucleo_nfc@0 {
 		compatible = "x-nucleo-nfc";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
 		spi-cs-setup-delay-ns = <1000>;
 		spi-cs-hold-delay-ns = <1000>;
 		irq-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;

--- a/applications/aliro-access-control-app/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/applications/aliro-access-control-app/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -35,7 +35,7 @@
 	nucleo_nfc@0 {
 		compatible = "x-nucleo-nfc";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
 		spi-cs-setup-delay-ns = <1000>;
 		spi-cs-hold-delay-ns = <1000>;
 		irq-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;

--- a/applications/aliro-access-control-app/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/applications/aliro-access-control-app/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -35,7 +35,7 @@
 	nucleo_nfc@0 {
 		compatible = "x-nucleo-nfc";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
 		spi-cs-setup-delay-ns = <1000>;
 		spi-cs-hold-delay-ns = <1000>;
 		irq-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;

--- a/applications/matter-aliro-door-lock-app/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/applications/matter-aliro-door-lock-app/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -48,7 +48,7 @@
 	nucleo_nfc@0 {
 		compatible = "x-nucleo-nfc";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
 		spi-cs-setup-delay-ns = <1000>;
 		spi-cs-hold-delay-ns = <1000>;
 		irq-gpios = <&gpio0 4 GPIO_ACTIVE_HIGH>;

--- a/applications/matter-aliro-door-lock-app/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/applications/matter-aliro-door-lock-app/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -35,7 +35,7 @@
 	nucleo_nfc@0 {
 		compatible = "x-nucleo-nfc";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
 		spi-cs-setup-delay-ns = <1000>;
 		spi-cs-hold-delay-ns = <1000>;
 		irq-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;

--- a/applications/matter-aliro-door-lock-app/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
+++ b/applications/matter-aliro-door-lock-app/boards/nrf54lm20dk_nrf54lm20b_cpuapp.overlay
@@ -35,7 +35,7 @@
 	nucleo_nfc@0 {
 		compatible = "x-nucleo-nfc";
 		reg = <0>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
 		spi-cs-setup-delay-ns = <1000>;
 		spi-cs-hold-delay-ns = <1000>;
 		irq-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;

--- a/snippets/uwb_qm35/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/snippets/uwb_qm35/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -12,7 +12,7 @@
 		status = "okay";
 		compatible = "qorvo,hsspi";
 		reg = <1>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
 		ss-irq-gpios = <&gpio0 26 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		reset-gpios = <&gpio1 9 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
 		exton-gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;

--- a/snippets/uwb_qm35/boards/nrf54lm20dk_cpuapp.overlay
+++ b/snippets/uwb_qm35/boards/nrf54lm20dk_cpuapp.overlay
@@ -12,7 +12,7 @@
 		status = "okay";
 		compatible = "qorvo,hsspi";
 		reg = <1>;
-		spi-max-frequency = <DT_FREQ_M(8)>;
+		spi-max-frequency = <DT_FREQ_M(4)>;
 		ss-irq-gpios = <&gpio0 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		reset-gpios = <&gpio3 7 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
 		exton-gpios = <&gpio3 12 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
- Improve signal integrity on the shared SPI bus.
- Reduce ringing and increase timing margin.