### PR TITLE
samples: Add matter only smp dfu sample for 54LM20 platform

### DIFF
--- a/applications/matter-door-lock-app/sample.yaml
+++ b/applications/matter-door-lock-app/sample.yaml
@@ -44,6 +44,7 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20b/cpuapp
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp


### PR DESCRIPTION
In this PR I added 54LM20 platform for sample.matter.lock.smp_dfu