### PR TITLE
door_lock_delegate: Return null for missing group resolving key

### DIFF
--- a/subsys/aliro/door_lock_delegate/src/door_lock_delegate.cpp
+++ b/subsys/aliro/door_lock_delegate/src/door_lock_delegate.cpp
@@ -151,7 +151,8 @@ CHIP_ERROR DoorLockDelegate::GetAliroGroupResolvingKey(chip::MutableByteSpan &gr
 
 	if (!DoorLock::ReaderStorage::IsGroupResolvingKeySet()) {
 		groupResolvingKey.reduce_size(0);
-		return CHIP_ERROR_NOT_FOUND;
+		// We have to return CHIP_NO_ERROR here.
+		return CHIP_NO_ERROR;
 	}
 
 	Aliro::CryptoTypes::GroupResolvingKey key{};


### PR DESCRIPTION
For BLE/UWB, the GroupResolvingKey is obligatory in SetAliroReaderConfig. However, GetAliroReaderConfig should still succeed if the config isn't set. Fix: return CHIP_NO_ERROR with an empty span when attempting to read GroupResolvingKey if it isn't set (gets encoded as null, instead of error).