### PR TITLE
applications: Improve credentials handling

### DIFF
--- a/applications/aliro-access-control-app/src/aliro/access_manager/access_manager_impl.cpp
+++ b/applications/aliro-access-control-app/src/aliro/access_manager/access_manager_impl.cpp
@@ -298,12 +298,8 @@ AliroError StoreAccessDocument(size_t keyIndex, size_t credentialIssuerKeyIndex,
 	return ALIRO_NO_ERROR;
 }
 
-bool IsCurrentAccessDocumentUpToDate(size_t keyIndex, const Timestamp &credentialSignedTimestamp)
+bool IsAccessDocumentUpToDate(const AccessDocument &ad, const Timestamp &credentialSignedTimestamp)
 {
-	AccessDocument ad;
-	const auto error = ReadAccessDocument(keyIndex, ad);
-	VerifyOrReturnFalse(error == ALIRO_NO_ERROR);
-
 	LOG_DBG("Saved timestamp: %.*s", ad.mSignedTimestamp.size(), ad.mSignedTimestamp.data());
 	LOG_DBG("New timestamp  : %.*s", credentialSignedTimestamp.size(), credentialSignedTimestamp.data());
 
@@ -354,9 +350,17 @@ std::optional<Interface::Access::AccessDocumentRequestParams> AccessManagerImpl:
 #if CONFIG_DOOR_LOCK_STORAGE_MAX_STORED_ACCESS_DOCUMENTS > 0
 	size_t keyIndex{};
 	if (IsPublicKeyStored(mAdKeys, publicKey, &keyIndex)) {
+		AccessDocument ad;
+		const auto error = ReadAccessDocument(keyIndex, ad);
+		if (error != ALIRO_NO_ERROR) {
+			LOG_WRN("Failed to read Access Document at index: %zu, error code: %d", keyIndex,
+				error.ToInt());
+			LOG_INF("Cached Access Document is missing or invalid, requesting Access Document");
+			return kAccessDocumentRequestParams;
+		}
+
 		if (credentialSignedTimestamp.has_value()) {
-			const auto isUpToDate =
-				IsCurrentAccessDocumentUpToDate(keyIndex, credentialSignedTimestamp.value());
+			const auto isUpToDate = IsAccessDocumentUpToDate(ad, credentialSignedTimestamp.value());
 			if (!isUpToDate) {
 				LOG_INF("User Device has newer Access Document");
 				return kAccessDocumentRequestParams;
@@ -383,17 +387,16 @@ AliroError AccessManagerImpl::_VerifyAccessCredential(
 	[[maybe_unused]] const std::optional<AccessDocumentTypes::AccessDocument> &accessDocument)
 {
 	AliroError status{ ALIRO_NO_ERROR };
+
+#ifdef CONFIG_DOOR_LOCK_STEP_UP_PHASE
+	if (accessDocument.has_value()) {
+		status = ProcessAccessDocument(userPublicKey, accessDocument.value());
+	} else
+#endif // CONFIG_DOOR_LOCK_STEP_UP_PHASE
 	{
 		MutexGuard lock{ sMutex };
 		status = VerifyPublicKey(userPublicKey) ? ALIRO_NO_ERROR : ALIRO_PUBLIC_KEY_NOT_FOUND;
 	}
-
-#ifdef CONFIG_DOOR_LOCK_STEP_UP_PHASE
-	if (status != ALIRO_NO_ERROR && accessDocument.has_value()) {
-		const auto &ad = accessDocument.value();
-		status = ProcessAccessDocument(userPublicKey, ad);
-	}
-#endif // CONFIG_DOOR_LOCK_STEP_UP_PHASE
 
 #ifdef CONFIG_DOOR_LOCK_EXPEDITED_FAST_PHASE
 	if (status == ALIRO_NO_ERROR && mKpersistentManager) {

--- a/applications/matter-aliro-door-lock-app/src/aliro/access_manager/access_manager_impl.cpp
+++ b/applications/matter-aliro-door-lock-app/src/aliro/access_manager/access_manager_impl.cpp
@@ -298,12 +298,8 @@ AliroError StoreAccessDocument(size_t keyIndex, size_t credentialIssuerKeyIndex,
 	return ALIRO_NO_ERROR;
 }
 
-bool IsCurrentAccessDocumentUpToDate(size_t keyIndex, const Timestamp &credentialSignedTimestamp)
+bool IsAccessDocumentUpToDate(const AccessDocument &ad, const Timestamp &credentialSignedTimestamp)
 {
-	AccessDocument ad;
-	const auto error = ReadAccessDocument(keyIndex, ad);
-	VerifyOrReturnFalse(error == ALIRO_NO_ERROR);
-
 	LOG_DBG("Saved timestamp: %.*s", ad.mSignedTimestamp.size(), ad.mSignedTimestamp.data());
 	LOG_DBG("New timestamp  : %.*s", credentialSignedTimestamp.size(), credentialSignedTimestamp.data());
 
@@ -354,9 +350,17 @@ std::optional<Interface::Access::AccessDocumentRequestParams> AccessManagerImpl:
 #if CONFIG_DOOR_LOCK_STORAGE_MAX_STORED_ACCESS_DOCUMENTS > 0
 	size_t keyIndex{};
 	if (IsPublicKeyStored(mAdKeys, publicKey, &keyIndex)) {
+		AccessDocument ad;
+		const auto error = ReadAccessDocument(keyIndex, ad);
+		if (error != ALIRO_NO_ERROR) {
+			LOG_WRN("Failed to read Access Document at index: %zu, error code: %d", keyIndex,
+				error.ToInt());
+			LOG_INF("Cached Access Document is missing or invalid, requesting Access Document");
+			return kAccessDocumentRequestParams;
+		}
+
 		if (credentialSignedTimestamp.has_value()) {
-			const auto isUpToDate =
-				IsCurrentAccessDocumentUpToDate(keyIndex, credentialSignedTimestamp.value());
+			const auto isUpToDate = IsAccessDocumentUpToDate(ad, credentialSignedTimestamp.value());
 			if (!isUpToDate) {
 				LOG_INF("User Device has newer Access Document");
 				return kAccessDocumentRequestParams;
@@ -383,17 +387,16 @@ AliroError AccessManagerImpl::_VerifyAccessCredential(
 	[[maybe_unused]] const std::optional<AccessDocumentTypes::AccessDocument> &accessDocument)
 {
 	AliroError status{ ALIRO_NO_ERROR };
+
+#ifdef CONFIG_DOOR_LOCK_STEP_UP_PHASE
+	if (accessDocument.has_value()) {
+		status = ProcessAccessDocument(userPublicKey, accessDocument.value());
+	} else
+#endif // CONFIG_DOOR_LOCK_STEP_UP_PHASE
 	{
 		MutexGuard lock{ sMutex };
 		status = VerifyPublicKey(userPublicKey) ? ALIRO_NO_ERROR : ALIRO_PUBLIC_KEY_NOT_FOUND;
 	}
-
-#ifdef CONFIG_DOOR_LOCK_STEP_UP_PHASE
-	if (status != ALIRO_NO_ERROR && accessDocument.has_value()) {
-		const auto &ad = accessDocument.value();
-		status = ProcessAccessDocument(userPublicKey, ad);
-	}
-#endif // CONFIG_DOOR_LOCK_STEP_UP_PHASE
 
 #ifdef CONFIG_DOOR_LOCK_EXPEDITED_FAST_PHASE
 	if (status == ALIRO_NO_ERROR && mKpersistentManager) {

--- a/applications/matter-aliro-door-lock-app/src/aliro/storage/access_document.cpp
+++ b/applications/matter-aliro-door-lock-app/src/aliro/storage/access_document.cpp
@@ -88,12 +88,19 @@ AliroError StoreAccessDocument(size_t index, const AccessDocument &ad)
 	VerifyOrReturnStatus(IsIndexInRange(index), ALIRO_INVALID_ARGUMENT,
 			     LOG_ERR("Access Document index out of range: %zu", index));
 
+	ReturnErrorOnFailure(UpdateAliroEvictableCredential(index, ad.mPublicKey, ad.mCredentialIssuerKeyIndex));
+
 	const auto id = GetExternalNvsId(index);
 	const auto error = DoorLock::ExternalNvs::Write(id, &ad, sizeof(AccessDocument));
-	VerifyOrReturnStatus(error == 0, AliroError::FromInt(error),
-			     LOG_ERR("Failed to store Access Document at index: %zu", index));
-
-	ReturnErrorOnFailure(UpdateAliroEvictableCredential(index, ad.mPublicKey, ad.mCredentialIssuerKeyIndex));
+	if (error != 0) {
+		LOG_ERR("Failed to store Access Document at index: %zu", index);
+		const auto rollbackError = RemoveAliroEvictableCredential(index, true);
+		if (rollbackError != ALIRO_NO_ERROR) {
+			LOG_ERR("Failed to revert Aliro evictable credential at index: %zu, error code: %d", index,
+				rollbackError.ToInt());
+		}
+		return AliroError::FromInt(error);
+	}
 
 	return ALIRO_NO_ERROR;
 }

--- a/applications/matter-aliro-door-lock-app/src/matter/bolt_lock_manager.cpp
+++ b/applications/matter-aliro-door-lock-app/src/matter/bolt_lock_manager.cpp
@@ -145,7 +145,7 @@ void BoltLockManager::Init(StateChangeCallback callback)
 				Aliro::AccessManager::PublicKeyType::CredentialIssuer, keyIndex);
 
 #ifdef CONFIG_DOOR_LOCK_STEP_UP_PHASE
-			Aliro::ClearValidityIterations(credentialIndex);
+			Aliro::ClearValidityIterations(keyIndex);
 #endif // CONFIG_DOOR_LOCK_STEP_UP_PHASE
 		}
 	};

--- a/subsys/matter_access/src/access_manager_credentials.cpp
+++ b/subsys/matter_access/src/access_manager_credentials.cpp
@@ -126,7 +126,15 @@ CHIP_ERROR AccessManager<CRED_BIT_MASK>::RemoveAliroEvictableCredential(uint16_t
 		/* Update the users credentials list */
 		auto &users = Instance().mUsers;
 		for (size_t idxUsr = 0; idxUsr < CONFIG_DOOR_LOCK_MATTER_ACCESS_MAX_NUM_USERS; ++idxUsr) {
-			users[idxUsr].RemoveAliroEvictableCredential(credentialIndex);
+			auto &user = users[idxUsr];
+
+			const auto userStatus = static_cast<UserStatusEnum>(user.mInfo.mFields.mUserStatus);
+			if (userStatus != UserStatusEnum::kOccupiedEnabled &&
+			    userStatus != UserStatusEnum::kOccupiedDisabled) {
+				continue;
+			}
+
+			user.RemoveAliroEvictableCredential(credentialIndex);
 		}
 	}
 


### PR DESCRIPTION
* Use correct index when removing Validity Iterations.
* Update Matter credentials before storing Access Document as Matter may run
out of slots.
* Request Access Document if it does not exist in the storage.
* Process Access Document before provisioned Access Credentials.
* Remove Aliro evictable credentials only from occupied users.