### PR TITLE
applications: access_manager: Update Access Documents removal condition

### DIFF
--- a/applications/aliro-access-control-app/src/aliro/access_manager/access_manager_impl.cpp
+++ b/applications/aliro-access-control-app/src/aliro/access_manager/access_manager_impl.cpp
@@ -1339,7 +1339,7 @@ AliroError AccessManagerImpl::RemoveOldCredentials(size_t credentialIssuerKeyInd
 			}
 
 			const auto diff = validityIteration - ad.mAccessIteration;
-			if (diff > kMaxValidityIterationDiff) {
+			if (diff >= kMaxValidityIterationDiff) {
 				LOG_DBG("Removing old credentials with index %u due to Validity Iteration difference: %" PRIu64,
 					i, diff);
 				ReturnErrorOnFailure(_RemovePublicKey(PublicKeyType::AccessDocument, i));

--- a/applications/matter-aliro-door-lock-app/src/aliro/access_manager/access_manager_impl.cpp
+++ b/applications/matter-aliro-door-lock-app/src/aliro/access_manager/access_manager_impl.cpp
@@ -1339,7 +1339,7 @@ AliroError AccessManagerImpl::RemoveOldCredentials(size_t credentialIssuerKeyInd
 			}
 
 			const auto diff = validityIteration - ad.mAccessIteration;
-			if (diff > kMaxValidityIterationDiff) {
+			if (diff >= kMaxValidityIterationDiff) {
 				LOG_DBG("Removing old credentials with index %u due to Validity Iteration difference: %" PRIu64,
 					i, diff);
 				ReturnErrorOnFailure(_RemovePublicKey(PublicKeyType::AccessDocument, i, true));


### PR DESCRIPTION
Remove Access Documents when the difference between its Validity Iteration and current Access Iteration is equal or greater than 8.