### PR TITLE
subsys: matter_access: Improve credential validation

### DIFF
--- a/docs/known_issues_and_limitations.rst
+++ b/docs/known_issues_and_limitations.rst
@@ -62,6 +62,16 @@ A known issue can list one or both of the following entries:
   Some known issues have a workaround.
   Sometimes, they are discovered later and added over time.
 
+The |REPO_NAME| v1.2.0
+**********************
+
+.. toggle::
+
+  AL-931: Access Manager is not aware of final unlock decision
+    In the |MATTER_ALIRO_APP_NAME|, the Aliro Access Manager makes its access decision based only on the Access Credential public key, before the Matter user data is evaluated.
+    When the public key belongs to a Matter user whose UserStatus is ``OccupiedDisabled``, the Access Manager still grants access over Aliro.
+    The Matter validation runs afterwards, denies the credential with the ``DisabledUserDenied`` error, and the bolt is not actuated, so the door remains locked and no lock operation event is generated.
+
 The |REPO_NAME| v1.1.0
 **********************
 

--- a/subsys/matter_access/src/access_manager.cpp
+++ b/subsys/matter_access/src/access_manager.cpp
@@ -133,17 +133,18 @@ bool AccessManager<CRED_BIT_MASK>::ValidateCredential(CredentialTypeEnum credent
 
 		uint16_t userIndex{};
 		if (GetCredentialUserIndex(static_cast<uint16_t>(index), credentialType, userIndex) == CHIP_NO_ERROR) {
+			LOG_DBG("Valid credential found, user index: %u, credential type: %u, credential index: %zu",
+				static_cast<unsigned>(userIndex), static_cast<unsigned>(credentialType), index);
+			error = OperationErrorEnum::kUnspecified;
 			result = ValidateCredentialResult{
 				.mUserIndex = userIndex,
 				.mCredential = LockOpCredentials{ credentialType, static_cast<uint16_t>(index) },
 			};
+			return true;
 		} else {
-			result = {};
+			LOG_DBG("Cannot find user index for given credential");
+			break;
 		}
-
-		LOG_DBG("Valid lock credential provided");
-		error = OperationErrorEnum::kUnspecified;
-		return true;
 	}
 
 	LOG_DBG("Invalid lock credential provided");

--- a/subsys/matter_access/src/access_manager.cpp
+++ b/subsys/matter_access/src/access_manager.cpp
@@ -133,6 +133,14 @@ bool AccessManager<CRED_BIT_MASK>::ValidateCredential(CredentialTypeEnum credent
 
 		uint16_t userIndex{};
 		if (GetCredentialUserIndex(static_cast<uint16_t>(index), credentialType, userIndex) == CHIP_NO_ERROR) {
+			const auto &user = mUsers[userIndex - 1];
+			const auto userStatus = static_cast<UserStatusEnum>(user.mInfo.mFields.mUserStatus);
+			if (userStatus == UserStatusEnum::kOccupiedDisabled) {
+				LOG_DBG("User %u is disabled, access is denied", static_cast<unsigned>(userIndex));
+				error = OperationErrorEnum::kDisabledUserDenied;
+				return false;
+			}
+
 			LOG_DBG("Valid credential found, user index: %u, credential type: %u, credential index: %zu",
 				static_cast<unsigned>(userIndex), static_cast<unsigned>(credentialType), index);
 			error = OperationErrorEnum::kUnspecified;

--- a/subsys/matter_access/src/access_manager_credentials.cpp
+++ b/subsys/matter_access/src/access_manager_credentials.cpp
@@ -223,8 +223,13 @@ CHIP_ERROR AccessManager<CRED_BIT_MASK>::GetCredentialUserIndex(uint16_t credent
 
 	for (size_t idxUsr = 0; idxUsr < CONFIG_DOOR_LOCK_MATTER_ACCESS_MAX_NUM_USERS; ++idxUsr) {
 		auto &user = Instance().mUsers[idxUsr];
-		const size_t numCredentials = user.mOccupiedCredentials.mSize / sizeof(CredentialStruct);
 
+		const auto userStatus = static_cast<UserStatusEnum>(user.mInfo.mFields.mUserStatus);
+		if (userStatus != UserStatusEnum::kOccupiedEnabled && userStatus != UserStatusEnum::kOccupiedDisabled) {
+			continue;
+		}
+
+		const size_t numCredentials = user.mOccupiedCredentials.mSize / sizeof(CredentialStruct);
 		for (size_t idxCred = 0; idxCred < numCredentials; ++idxCred) {
 			auto &credentialStruct = user.mOccupiedCredentials.mData[idxCred];
 			if (credentialStruct.credentialIndex == credentialIndex &&


### PR DESCRIPTION
* Skip unoccupied users when searching for credential owner.
* Deny access when credential has no owner.
* Deny access when the user is occupied but disabled.
* Add known issue for AL-931.